### PR TITLE
Add SequentialExecutorService that assists Pub/Sub to publish messages sequentially

### DIFF
--- a/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SequentialExecutorService.java
+++ b/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SequentialExecutorService.java
@@ -1,0 +1,227 @@
+package com.google.cloud.pubsub.v1;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.pubsub.v1.PublishResponse;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+
+interface CancellableRunnable extends Runnable {
+  public void cancel(Throwable e);
+}
+
+/**
+ * An executor service that runs the tasks with the same key sequentially. The tasks with the same
+ * key will be run only when its predecessor has been completed while tasks with different keys can
+ * be run in parallel.
+ */
+final class SequentialExecutorService<T> {
+  private final SequentialExecutor manageableSequentialExecutor;
+  private final SequentialExecutor autoSequentialExecutor;
+
+  public SequentialExecutorService(Executor executor) {
+    this.manageableSequentialExecutor = SequentialExecutor.newManageableSequentialExecutor(executor);
+    this.autoSequentialExecutor = SequentialExecutor.newAutoSequentialExecutor(executor);
+  }
+
+  /**
+   * Runs asynchronous {@code Callable} tasks sequentially. If one of the tasks fails, other tasks
+   * with the same key that have not been executed will be cancelled.
+   */
+  public ApiFuture<T> submit(final String key, final Callable<ApiFuture> callable) {
+    final SettableApiFuture<T> future = SettableApiFuture.<T>create();
+    manageableSequentialExecutor.execute(key, new CancellableRunnable() {
+      private boolean cancelled = false;
+
+      @Override
+      public void run() {
+        if (cancelled) {
+          return;
+        }
+        try {
+          ApiFuture<T> callResult = callable.call();
+          ApiFutures.addCallback(callResult, new ApiFutureCallback<T>() {
+            @Override
+            public void onSuccess(T msg) {
+              future.set(msg);
+              manageableSequentialExecutor.resume(key);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+              future.setException(e);
+              manageableSequentialExecutor.cancelQueuedTasks(key,
+                  new CancellationException(
+                      "Publishing cancelled since delivering previous message has been failed."));
+            }
+          });
+        } catch (Exception e) {
+
+        }
+      }
+
+      @Override
+      public void cancel(Throwable e) {
+        this.cancelled = true;
+        future.setException(e);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Runs synchronous {@code Runnable} tasks sequentially.
+   */
+  public void submit(final String key, final Runnable runnable) {
+    autoSequentialExecutor.execute(key, runnable);
+  }
+
+  /**
+   * Internal implemenation of SequentialExecutorService. Takes a serial stream of string keys and
+   * {@code Runnable} tasks, and runs the tasks with the same key sequentially. Tasks with the same
+   * key will be run only when its predecessor has been completed while tasks with different keys
+   * can be run in parallel.
+   */
+  static class SequentialExecutor {
+    // Maps keys to tasks.
+    private final Map<String, Deque<Runnable>> tasksByKey;
+    private final Executor executor;
+
+    enum TaskCompleteAction {
+      EXECUTE_NEXT_TASK,
+      WAIT_UNTIL_RESUME,
+    }
+    private TaskCompleteAction taskCompleteAction;
+
+    /**
+     * Creates a AutoSequentialExecutor which executes the next queued task automatically when the
+     * previous task has completed.
+     */
+    public static SequentialExecutor newAutoSequentialExecutor(Executor executor) {
+      return new SequentialExecutor(executor, TaskCompleteAction.EXECUTE_NEXT_TASK);
+    }
+
+    /**
+     * Creates a ManageableSequentialExecutor which allows users to decide when to execute the next
+     * queued task. The first queued task is executed immediately, but the following tasks will be
+     * executed only when {@link #resume(String)} is called explicitly.
+     */
+    public static SequentialExecutor newManageableSequentialExecutor(Executor executor) {
+      return new SequentialExecutor(executor, TaskCompleteAction.WAIT_UNTIL_RESUME);
+    }
+
+    private SequentialExecutor(Executor executor, TaskCompleteAction taskCompleteAction) {
+      this.executor = executor;
+      this.taskCompleteAction = taskCompleteAction;
+      this.tasksByKey = new HashMap<>();
+    }
+
+    public void execute(final String key, Runnable task) {
+      Deque<Runnable> newTasks;
+      synchronized (tasksByKey) {
+        newTasks = tasksByKey.get(key);
+        // If this key is already being handled, add it to the queue and return.
+        if (newTasks != null) {
+          newTasks.add(task);
+          return;
+        }
+
+        newTasks = new ConcurrentLinkedDeque();
+        newTasks.add(task);
+        tasksByKey.put(key, newTasks);
+      }
+
+      final Deque<Runnable> finalTasks = newTasks;
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          if (taskCompleteAction.equals(TaskCompleteAction.EXECUTE_NEXT_TASK)) {
+            invokeCallbackAndExecuteNext(key, finalTasks);
+          } else if (taskCompleteAction.equals(TaskCompleteAction.WAIT_UNTIL_RESUME)) {
+            invokeCallback(key, finalTasks);
+          }
+        }
+      });
+    }
+
+    /** Cancels every task in the queue assoicated with {@code key}. */
+    public void cancelQueuedTasks(final String key, Throwable e) {
+      // TODO(kimkyung-goog): Ensure execute() fails once cancelQueueTasks() has been ever invoked,
+      // so that no more tasks are scheduled.
+      synchronized (tasksByKey) {
+        final Deque<Runnable> tasks = tasksByKey.get(key);
+        if (tasks == null) {
+          return;
+        }
+        while (!tasks.isEmpty()) {
+          Runnable task = tasks.poll();
+          if (task instanceof CancellableRunnable) {
+            ((CancellableRunnable) task).cancel(e);
+          }
+        }
+      }
+    }
+
+    /** Executes the next queued task associated with {@code key}. */
+    public void resume(final String key) {
+      if (taskCompleteAction.equals(TaskCompleteAction.EXECUTE_NEXT_TASK)) {
+        // resume() is no-op since tasks are executed automatically.
+        return;
+      }
+      Deque<Runnable> tasks;
+      synchronized (tasksByKey) {
+        tasks = tasksByKey.get(key);
+        if (tasks == null) {
+          return;
+        }
+        if (tasks.isEmpty()) {
+          tasksByKey.remove(key);
+          return;
+        }
+      }
+      final Deque<Runnable> finalTasks = tasks;
+      // Run the next task.
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          invokeCallback(key, finalTasks);
+        }
+      });
+    }
+
+    private void invokeCallback(final String key, final Deque<Runnable> tasks) {
+      // TODO(kimkyung-goog): Check if there is a race when task list becomes empty.
+      Runnable task = tasks.poll();
+      if (task != null) {
+        task.run();
+      }
+    }
+
+    private void invokeCallbackAndExecuteNext(final String key, final Deque<Runnable> tasks) {
+      invokeCallback(key, tasks);
+      synchronized (tasksByKey) {
+        if (tasks.isEmpty()) {
+          // Note that there can be a race if a task is added to `tasks` at this point. However,
+          // tasks.add() is called only inside the block synchronized by `tasksByKey` object
+          // in the execute() function. Therefore, we are safe to remove `tasks` here. This is not
+          // optimal, but correct.
+          tasksByKey.remove(key);
+          return;
+        }
+      }
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          invokeCallbackAndExecuteNext(key, tasks);
+        }
+      });
+    }
+  }
+}

--- a/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SequentialExecutorServiceTest.java
+++ b/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SequentialExecutorServiceTest.java
@@ -1,0 +1,230 @@
+package com.google.cloud.pubsub.v1;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class SequentialExecutorServiceTest {
+  private final ExecutorProvider executorProvider =
+      InstantiatingExecutorProvider.newBuilder()
+          .setExecutorThreadCount(5 * Runtime.getRuntime().availableProcessors())
+          .build();
+
+  static class AsyncTaskCallable implements Callable<ApiFuture> {
+    boolean isCalled = false;
+    SettableApiFuture<String> result = SettableApiFuture.<String>create();
+
+    @Override
+    public ApiFuture<String> call() {
+      isCalled = true;
+      return result;
+    }
+
+    public boolean isCalled() {
+      return isCalled;
+    }
+
+    public void finishWithError(Throwable e) {
+      result.setException(e);
+    }
+
+    public void finish() {
+      result.set("ok");
+    }
+  }
+
+  @Test
+  public void testExecutorRunsNextTaskWhenPrevResponseReceived() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key", callable3);
+
+    Thread.sleep(1000);
+    assertFalse(callable2.isCalled());
+    assertFalse(callable3.isCalled());
+    callable1.finish();
+    assertEquals("ok", result1.get());
+
+    assertFalse(callable3.isCalled());
+    callable2.finish();
+    assertEquals("ok", result2.get());
+
+    callable3.finish();
+    assertEquals("ok", result3.get());
+  }
+
+  @Test
+  public void testExecutorRunsDifferentKeySimultaneously() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    // Submit three tasks (two tasks with "key", and one task with "key2").
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key2", callable3);
+
+    // The task associated with "key2" can be run in parallel with other tasks with "key".
+    callable3.finish();
+    assertEquals("ok", result3.get());
+
+    // Sleep some time to give the test a chance to fail. Verify that the second task has not been
+    // executed while the main thread is slpeeing.
+    Thread.sleep(100);
+    assertFalse(callable2.isCalled());
+    // Complete the first task.
+    callable1.finish();
+    assertEquals("ok", result1.get());
+    // Now, the second task can be executed.
+    callable2.finish();
+    assertEquals("ok", result2.get());
+  }
+
+  @Test
+  public void testExecutorCancelsAllTasksWhenOneFailed() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key", callable3);
+
+    Throwable failure = new Exception("failure");
+    callable1.finishWithError(failure);
+    // The failed task throws an exception that contains the cause of the failure.
+    try {
+      result1.get();
+      fail("Should have thrown an ExecutionException");
+    } catch (ExecutionException e) {
+      assertEquals(failure, e.getCause());
+    }
+    // Other tasks in the queue are expected to fail with a CancellationException.
+    for (ApiFuture<String> result : ImmutableList.of(result2, result3)) {
+      try {
+        result.get();
+        fail("Should have thrown an ExecutionException");
+      } catch (ExecutionException e) {
+        assertThat(e.getCause()).isInstanceOf(CancellationException.class);
+      }
+    }
+  }
+
+  /**
+   * A task that sleeps {@code taskDurationMillis} milliseconds. Appends its {@code taskId} to
+   * {@code startedTasksSequence} before sleeping and appends it to {@code completedTasksSequence}
+   * when sleeping is done.
+   */
+  static class SleepingSyncTask implements Runnable {
+    private final int taskId;
+    private final long taskDurationMillis;
+    private final LinkedHashSet<Integer> startedTasksSequence;
+    private final LinkedHashSet<Integer> completedTasksSequence;
+    private final CountDownLatch remainingTasksCount;
+
+    public SleepingSyncTask(
+        int taskId,
+        long taskDurationMillis,
+        LinkedHashSet<Integer> startedTasksSequence,
+        LinkedHashSet<Integer> completedTasksSequence,
+        CountDownLatch remainingTasksCount) {
+      this.taskId = taskId;
+      this.taskDurationMillis = taskDurationMillis;
+      this.startedTasksSequence = startedTasksSequence;
+      this.completedTasksSequence = completedTasksSequence;
+      this.remainingTasksCount = remainingTasksCount;
+    }
+
+    @Override
+    public void run() {
+      if (taskId > 0) {
+        // Verify that the previous task has been completed.
+        assertTrue(startedTasksSequence.contains(taskId - 1));
+        assertTrue(completedTasksSequence.contains(taskId - 1));
+      }
+      startedTasksSequence.add(taskId);
+      try {
+        Thread.sleep(taskDurationMillis);
+      } catch (InterruptedException e) {
+        return;
+      }
+      completedTasksSequence.add(taskId);
+      remainingTasksCount.countDown();
+
+      // Verify that the next task has not been started yet.
+      assertFalse(startedTasksSequence.contains(taskId + 1));
+      assertFalse(completedTasksSequence.contains(taskId + 1));
+    }
+  }
+
+  @Test
+  public void SequentialExecutorRunsTasksAutomatically() throws Exception {
+    int numKeys = 100;
+    int numTasks = 100;
+    SequentialExecutorService sequentialExecutor =
+        new SequentialExecutorService(executorProvider.getExecutor());
+    CountDownLatch remainingTasksCount = new CountDownLatch(numKeys * numTasks);
+    // Maps keys to lists of started and completed tasks.
+    Map<String, LinkedHashSet<Integer>> startedTasks = new HashMap<>();
+    Map<String, LinkedHashSet<Integer>> completedTasks = new HashMap<>();
+
+    for (int i = 0; i < numKeys; i++) {
+      String key = "key" + i;
+      LinkedHashSet<Integer> startedTasksSequence = new LinkedHashSet<>();
+      LinkedHashSet<Integer> completedTasksSequence = new LinkedHashSet<>();
+      startedTasks.put(key, completedTasksSequence);
+      completedTasks.put(key, completedTasksSequence);
+      for (int taskId = 0; taskId < numTasks; taskId++) {
+        SleepingSyncTask task = new SleepingSyncTask(
+            taskId, 10, startedTasksSequence, completedTasksSequence, remainingTasksCount);
+        sequentialExecutor.submit(key, task);
+      }
+    }
+
+    remainingTasksCount.await();
+
+    for (int i = 0; i < numKeys; i++) {
+      LinkedHashSet<Integer> startedTasksSequence = startedTasks.get("key" + i);
+      LinkedHashSet<Integer> completedTasksSequence = completedTasks.get("key" + i);
+      // Verify that the tasks have been started and completed in order.
+      int expectedTaskId = 0;
+      Iterator<Integer> it1 = startedTasksSequence.iterator();
+      Iterator<Integer> it2 = completedTasksSequence.iterator();
+      while (it1.hasNext() && it2.hasNext()) {
+        assertEquals(expectedTaskId, it1.next().intValue());
+        assertEquals(expectedTaskId, it2.next().intValue());
+        expectedTaskId++;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding SequentialExecutorService that runs user tasks sequentially. A task is executed only when the previous task has been completed. SequentialExecutorService internally uses manageableSequentialExecutor for asynchronous task, and uses autoSequentialExecutor for synchronous task.